### PR TITLE
Handle DuplicateObject and other exceptions

### DIFF
--- a/lib/pg_ldap_sync/application.rb
+++ b/lib/pg_ldap_sync/application.rb
@@ -214,7 +214,13 @@ class Application
   def pg_exec_modify(sql)
     log.info{ "SQL: #{sql}" }
     unless self.test
-      res = @pgconn.exec sql
+      begin
+        res = @pgconn.exec sql
+      rescue PG::DuplicateObject => dup
+        log.warn{ dup }
+      rescue PG::DependentObjectsStillExist => dep
+        log.warn{ dep }
+      end
     end
   end
 


### PR DESCRIPTION
Do this because when re-running the script (either to add more users
from existing groups or to add new groups) it bombs when it finds a
duplicate user.  

The error I was receiving when re-running it was as follows:
`C:/Ruby22/lib/ruby/gems/2.2.0/gems/pg-ldap-sync-0.1.1/lib/pg_ldap_sync/application.rb:218:in exec: ERROR:  role "<user.name>" already exists (PG::DuplicateObject)`

Once that was fixed I had to also rescue PG::DependentObjectsStillExist as well. 

This is my first foray into Ruby, so if there is a better or "more ruby-like" way to do it I would love to hear about it. 

Thanks