### PR TITLE
Support synchronize groups with over 1500 users in AD server

### DIFF
--- a/config/sample-config2.yaml
+++ b/config/sample-config2.yaml
@@ -38,6 +38,8 @@ ldap_groups:
   lowercase_name: false
   # this attribute must reference to all member DN's of the given group
   member_attribute: member
+  # must be true if group with over 1500 members for Active Directory server
+  need_member_range_retrieval: false
 
 # Connection parameters to PostgreSQL server
 # see also: http://rubydoc.info/gems/pg/PG/Connection#initialize-instance_method

--- a/config/sample-config2.yaml
+++ b/config/sample-config2.yaml
@@ -37,9 +37,10 @@ ldap_groups:
   # lowercase name for use as PG role name
   lowercase_name: false
   # this attribute must reference to all member DN's of the given group
+  # If LDAP server is Active Directory, it's better to append ";range" to member_attribue; 
+  # otherwise, it can't synchronize groups with over 1500 users for AD server.
+  # Example for AD server: "member;range"  
   member_attribute: member
-  # must be true if group with over 1500 members for Active Directory server
-  need_member_range_retrieval: false
 
 # Connection parameters to PostgreSQL server
 # see also: http://rubydoc.info/gems/pg/PG/Connection#initialize-instance_method

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -46,6 +46,9 @@ mapping:
       "member_attribute":
         type: str
         required:  yes
+      "need_member_range_retrieval":
+        type: bool
+        required:  no
 
   "pg_connection":
     type:      any

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -46,9 +46,6 @@ mapping:
       "member_attribute":
         type: str
         required:  yes
-      "need_member_range_retrieval":
-        type: bool
-        required:  no
 
   "pg_connection":
     type:      any

--- a/lib/pg_ldap_sync/application.rb
+++ b/lib/pg_ldap_sync/application.rb
@@ -90,7 +90,7 @@ class Application
     all_group_members = []
     while true do
       member_size = 0
-      member_attribute_with_range = "#{@config[:ldap_groups][:member_attribute]};range=#{range_start}-*"
+      member_attribute_with_range = "#{@config[:ldap_groups][:member_attribute]}=#{range_start}-*"
       returned_member_attribute_with_range = ""
       log.debug " current attribute for range retrieval ----> #{member_attribute_with_range} "
 
@@ -141,8 +141,9 @@ class Application
       end
 
       names.each do |n|
-        group_members = entry[ldap_group_conf[:member_attribute]]
-        if group_members.count == 0 and ldap_group_conf[:need_member_range_retrieval]
+        member_attribute_sub_list = ldap_group_conf[:member_attribute].partition(";")
+        group_members = entry[member_attribute_sub_list[0]]
+        if group_members.count == 0 and member_attribute_sub_list[2] == "range"
           group_members = load_group_members_by_range(entry.dn)
         end
         groups << LdapRole.new(n, entry.dn, group_members)


### PR DESCRIPTION
This pr fixes issue that it can't synchronize groups with over 1500 users from Active Directory server to PostgreSQL.

This issue is caused by the maximum limit for the number of attribute values AD server returns in a single query.
(Look at [https://docs.microsoft.com/zh-cn/previous-versions/windows/desktop/ldap/searching-using-range-retrieval?redirectedfrom=MSDN] for more details)

Let's take multi-valued attribute member of group as an example and look at the behavior of AD server (Windows Server 2003).
Case 1: If a group has 1500 or fewer member values (users), a search query will return the member attribute with all of the values in a single call.
Case 2: If a group has over 1500 member values (users), a search query will return the member attribute with no values, and an additional member;range=0-1499 attribute that contains the first 1500 member values in a single call.

When the member_attribute is set to **_member_** in the config file, pg-sync-ldap will find no values for the member attribute of group with over 1500 members.
When the member_attribute is set to **_member;range=0-1499_** in the config file, pg-sync-ldap will find only the first 1500 values for the member attribute of group with over 1500 members.

To solve this issue, this pr adds additional process for synchronizing groups with over 1500 users from AD (Active Directory) server to PostgreSQL.
We do repeated search query using a range specifier to get all members of group with over 1500 users.