### PR TITLE
Avoid usage of port 54321 for tests but use 23456

### DIFF
--- a/test/fixtures/config-ldapdb-bothcase.yaml
+++ b/test/fixtures/config-ldapdb-bothcase.yaml
@@ -19,7 +19,7 @@ ldap_groups:
 pg_connection:
   dbname: postgres
   host: localhost
-  port: 54321
+  port: 23456
 # needed for postgres-pr:
 #   user: insert_your_username_here
 #   password:

--- a/test/fixtures/config-ldapdb.yaml
+++ b/test/fixtures/config-ldapdb.yaml
@@ -17,7 +17,7 @@ ldap_groups:
 pg_connection:
   dbname: postgres
   host: localhost
-  port: 54321
+  port: 23456
 # needed for postgres-pr:
 #   user: insert_your_username_here
 #   password:

--- a/test/test_pg_ldap_sync.rb
+++ b/test/test_pg_ldap_sync.rb
@@ -52,7 +52,7 @@ class TestPgLdapSync < Minitest::Test
   end
 
   def start_pg_server
-    @port = 54321
+    @port = 23456
     ENV['PGPORT'] = @port.to_s
     ENV['PGHOST'] = 'localhost'
     unless File.exist?('temp/pg_data/PG_VERSION')


### PR DESCRIPTION
54321 is an ephemeral port on most operating systems, so that is's sometimes already in use in CI. This makes initdb fail sometimes on Windows like so:

```
Command failed: [pg_ctl -w -o -k. -D temp/pg_data start]
waiting for server to start....2025-03-22 11:49:32.782 UTC [1432] LOG:  starting PostgreSQL 17.0 on x86_64-windows, compiled by msvc-19.41.34120, 64-bit
2025-03-22 11:49:32.785 UTC [1432] LOG:  could not bind IPv6 address "::1": Permission denied
2025-03-22 11:49:32.785 UTC [1432] LOG:  could not bind IPv4 address "127.0.0.1": Permission denied
2025-03-22 11:49:32.785 UTC [1432] WARNING:  could not create listen socket for "localhost"
2025-03-22 11:49:32.785 UTC [1432] FATAL:  could not create any TCP/IP sockets
2025-03-22 11:49:32.786 UTC [1432] LOG:  database system is shut down
```