### PR TITLE
Replace kwalify by json-schema

### DIFF
--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -1,74 +1,78 @@
-type:       map
-mapping:
-  "ldap_connection":
-    type:      any
-    required:  yes
+"$schema": "http://json-schema.org/draft-04/schema#"
+"id": "https://github.com/larskanis/pg-ldap-sync/blob/-/config/schema.yaml"
+title: pg-ldap-sync config file
+type: object
+required:
+  - ldap_connection
+  - ldap_users
+  - ldap_groups
+  - pg_connection
+  - pg_users
+  - pg_groups
+properties:
+  ldap_connection:
+    type: object
 
-  "ldap_users":
-    type: map
-    required: yes
-    mapping:
-      "base":
-        type: str
-        required:  yes
-      "filter":
-        type: str
-        required:  yes
-      "name_attribute":
-        type: str
-        required:  yes
-      "lowercase_name":
-        type: bool
-        required:  no
-      "bothcase_name":
-        type: bool
-        required:  no
+  ldap_users:
+    type: object
+    required:
+      - base
+      - filter
+      - name_attribute
+    properties:
+      base:
+        type: string
+      filter:
+        type: string
+      name_attribute:
+        type: string
+      lowercase_name:
+        type: boolean
+      bothcase_name:
+        type: boolean
 
-  "ldap_groups":
-    type: map
-    required: yes
-    mapping:
-      "base":
-        type: str
-        required:  yes
-      "filter":
-        type: str
-        required:  yes
-      "name_attribute":
-        type: str
-        required:  yes
-      "lowercase_name":
-        type: bool
-        required:  no
-      "bothcase_name":
-        type: bool
-        required:  no
-      "member_attribute":
-        type: str
-        required:  yes
+  ldap_groups:
+    type: object
+    required:
+      - base
+      - filter
+      - name_attribute
+      - member_attribute
+    properties:
+      base:
+        type: string
+      filter:
+        type: string
+      name_attribute:
+        type: string
+      lowercase_name:
+        type: boolean
+      bothcase_name:
+        type: boolean
+      member_attribute:
+        type: string
 
-  "pg_connection":
-    type:      any
-    required:  yes
+  pg_connection:
+    type: object
 
-  "pg_users":
-    type: map
-    required: yes
-    mapping:
-      "filter":
-        type: str
-        required:  yes
-      "create_options":
-        type: str
+  pg_users:
+    type: object
+    required:
+      - filter
+    properties:
+      filter:
+        type: string
+      create_options:
+        type: ["string", "null"]
 
-  "pg_groups":
-    type: map
-    required: yes
-    mapping:
-      "filter":
-        type: str
-        required:  yes
-      "create_options":
-        type: str
-      "grant_options":
-        type: str
+  pg_groups:
+    type: object
+    required:
+      - filter
+    properties:
+      filter:
+        type: string
+      create_options:
+        type: ["string", "null"]
+      grant_options:
+        type: ["string", "null"]

--- a/lib/pg_ldap_sync/application.rb
+++ b/lib/pg_ldap_sync/application.rb
@@ -3,7 +3,7 @@
 require "net/ldap"
 require "optparse"
 require "yaml"
-require "kwalify"
+require "json-schema"
 require "pg"
 require "pg_ldap_sync/logger"
 
@@ -26,11 +26,10 @@ module PgLdapSync
 
     def validate_config(config, schema, fname)
       schema = YAML.load_file(schema)
-      validator = Kwalify::Validator.new(schema)
-      errors = validator.validate(config)
+      errors = JSON::Validator.fully_validate(schema, config, validate_schema: true, insert_defaults: true)
       if errors && !errors.empty?
         errors.each do |err|
-          log.fatal "error in #{fname}: [#{err.path}] #{err.message}"
+          log.fatal "error in #{fname}: #{err}"
         end
         raise InvalidConfig, 78 # EX_CONFIG
       end

--- a/pg-ldap-sync.gemspec
+++ b/pg-ldap-sync.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3"
 
   spec.add_runtime_dependency "net-ldap", "~> 0.16"
-  spec.add_runtime_dependency "kwalify", "~> 0.7"
+  spec.add_runtime_dependency "json-schema", ">= 2"
   spec.add_runtime_dependency "pg", ">= 0.14", "< 2.0"
   spec.add_runtime_dependency "logger", "~> 1.0"
   spec.add_runtime_dependency "ostruct", "~> 0.1" # workaround missing dependency in net-ldap-0.19.0

--- a/test/test_pg_ldap_sync.rb
+++ b/test/test_pg_ldap_sync.rb
@@ -144,7 +144,7 @@ class TestPgLdapSync < Minitest::Test
   end
 
   def test_invalid_config
-    assert_output(/key 'ldap_users:' is required/) do
+    assert_output(/required property of 'ldap_users'.*property '#\/ldap_connection' of type null/m) do
       assert_raises(PgLdapSync::InvalidConfig) do
         sync_with_config("config-invalid")
       end


### PR DESCRIPTION
kwalify isn't maintained any longer and we don't need any YAML features beyond JSON for schema validation.