### PR TITLE
Allow ERb syntax in config file

### DIFF
--- a/lib/pg_ldap_sync/application.rb
+++ b/lib/pg_ldap_sync/application.rb
@@ -2,6 +2,7 @@
 
 require "net/ldap"
 require "optparse"
+require "erb"
 require "yaml"
 require "json-schema"
 require "pg"
@@ -37,7 +38,7 @@ module PgLdapSync
 
     def read_config_file(fname)
       raise "Config file #{fname.inspect} does not exist" unless File.exist?(fname)
-      config = YAML.load_file(fname)
+      config = YAML.load(ERB.new(File.read(fname)).result)
 
       schema_fname = File.join(File.dirname(__FILE__), "../../config/schema.yaml")
       validate_config(config, schema_fname, fname)

--- a/pg-ldap-sync.gemspec
+++ b/pg-ldap-sync.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = %w[--main README.md --charset=UTF-8]
   spec.required_ruby_version = ">= 2.3"
 
+  spec.add_runtime_dependency "erb", ">= 1"
   spec.add_runtime_dependency "net-ldap", "~> 0.16"
   spec.add_runtime_dependency "json-schema", ">= 2"
   spec.add_runtime_dependency "pg", ">= 0.14", "< 2.0"

--- a/test/fixtures/config-ldapdb-bothcase.yaml
+++ b/test/fixtures/config-ldapdb-bothcase.yaml
@@ -1,7 +1,7 @@
 ---
 ldap_connection:
   host: localhost
-  port: 1389
+  port: <%= ENV["LDAP_PORT"] || 999 %>
 
 ldap_users:
   base: dc=example,dc=com

--- a/test/test_pg_ldap_sync.rb
+++ b/test/test_pg_ldap_sync.rb
@@ -170,13 +170,16 @@ class TestPgLdapSync < Minitest::Test
     assert_role("Fred", "", ["All Users", "Flintstones", "Wilmas"])
   end
 
-  def test_add_membership_bothcase
+  def test_add_membership_bothcase_with_erb
+    old_env, ENV['LDAP_PORT'] = ENV['LDAP_PORT'], "1389"
     sync_change(config: "config-ldapdb-bothcase") do |dir|
       # add 'Fred' to 'Wilmas'
       @directory[0]["cn=Wilmas,dc=example,dc=com"]["member"] << "cn=Fred Flintstone,dc=example,dc=com"
     end
     assert_role("fred", "", ["All Users", "all users", "Flintstones", "flintstones", "Wilmas", "wilmas"])
     assert_role("Fred", "", ["All Users", "all users", "Flintstones", "flintstones", "Wilmas", "wilmas"])
+  ensure
+    ENV['LDAP_PORT'] = old_env
   end
 
   def test_revoke_membership


### PR DESCRIPTION
That way Ruby code can be used to insert environment variables like so:

```
  password: <%= ENV["PASSWORD"] %>
```

Fixes #31
Fixes #46